### PR TITLE
Use cuda-nvtx.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
 build:
   number: 2
   script: {{ PYTHON }} -m pip install . -vv
+  ignore_run_exports_from:
+    - cuda-nvtx
 
 requirements:
   build:
@@ -21,7 +23,7 @@ requirements:
     - cython
     - pip
     - python
-    - nvtx-c
+    - cuda-nvtx
   run:
     - python
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR uses the new package `cuda-nvtx` instead of `nvtx-c` as the source of the NVTX headers. We ignore the `run_exports` of that package, to avoid introducing a `__cuda` metapackage dependency on the driver version. This `nvtx` package is independent of CUDA version and supports CPU-only as well.